### PR TITLE
Fix - failed "goto definition" opens new buffer

### DIFF
--- a/commands/go_to_definition.py
+++ b/commands/go_to_definition.py
@@ -11,7 +11,7 @@ class OmniSharpGoToDefinition(sublime_plugin.TextCommand):
             self.view, '/gotodefinition', self._handle_gotodefinition)
 
     def _handle_gotodefinition(self, data):
-        if data is None:
+        if data is None or data['FileName'] is None:
             return
 
         filename = data['FileName']


### PR DESCRIPTION
When using the sublime text Omnisharp plugin on Windows instead of mono, the goto definition function, when used on something without known definition, opens a new empty buffer. This fixes that to instead do nothing.
