### PR TITLE
Fix a typo that break all commands in the command palette

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,7 +8,7 @@
         "caption": "OmniSharpSublime: Rename"
     },
     {
-        "command": "omni_sharp__find_usages",
+        "command": "omni_sharp_find_usages",
         "caption": "OmniSharpSublime: Find Usages"
     },
     {
@@ -23,7 +23,6 @@
         "command": "omni_sharp_override_targets",
         "caption": "OmniSharpSublime: Override Targets"
     },
-    ,
     {
         "command": "omni_sharp_add_reference",
         "caption": "OmniSharpSublime: Add Reference"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
  4. Goto definition
  5. Rename
  6. Add Reference
+ 7. Find Usage
 
 # Requirements
  * Mono Development Kit(for [OmniSharpServer](https://github.com/nosami/OmniSharpServer))


### PR DESCRIPTION
and one that doesnt show Find Usage in the command palette
