### PR TITLE
"Sublime Package Manager" to "Package Control"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ It works on:
 
 #Installation
 
- * Using the Sublime Package Manager install the package called `OmniSharp`
+ * Using [Package Control](https://packagecontrol.io), install the package `OmniSharp`
 
 # Building From Source
 1. Move to ST3 plugin directory in console.


### PR DESCRIPTION
Use the correct name for Package Control, add a link.
