### PR TITLE
Add omnisharp_onsave_codecheck setting

### DIFF
--- a/OmniSharpSublime.sublime-settings
+++ b/OmniSharpSublime.sublime-settings
@@ -1,5 +1,6 @@
 {
     "omnisharp_response_timeout": 100,
     "omnisharp_auto_start": true,
-    "omnisharp_server_config_location":""
+    "omnisharp_server_config_location":"",
+    "omnisharp_onsave_codecheck": true
 }

--- a/listeners/syntax.py
+++ b/listeners/syntax.py
@@ -22,8 +22,8 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
         self.outputpanel.run_command('erase_view')
 
         self.view.erase_regions("oops")
-
-        omnisharp.get_response(view, '/codecheck', self._handle_codeerrors)
+        if bool(helpers.get_settings(view, 'omnisharp_onsave_codecheck')):
+            omnisharp.get_response(view, '/codecheck', self._handle_codeerrors)
 
         print('file changed')
 


### PR DESCRIPTION
This commit allow to user disable code checking after saving. I think there are a lot people who press super+s very frequently and hate this jumping window with warnings ;) 
User can just add this line to his "sublime-settings":
_"omnisharp_onsave_codecheck": true_
![Screenshot](http://gyazo.halfbusstudio.com/b46b5d.png)
