### PR TITLE
klr.exe isn't available in the AppData\Roaming\Sublime Text

### DIFF
--- a/PrebuiltOmniSharpServer/omnisharp.cmd
+++ b/PrebuiltOmniSharpServer/omnisharp.cmd
@@ -1,2 +1,2 @@
 
-@"%~dp0approot\packages\KRE-Mono.1.0.0-beta2\bin\klr.exe" --appbase "%~dp0approot\packages\OmniSharp\1.0.0\root" Microsoft.Framework.ApplicationHost omnisharp %*
+@"klr.exe" --appbase "%~dp0approot\packages\OmniSharp\1.0.0\root" Microsoft.Framework.ApplicationHost omnisharp %*


### PR DESCRIPTION
klr.exe isn't available in the AppData\Roaming\Sublime Text 3\Packages\omnisharp-sublime\PrebuiltOmniSharpServer\approot\packages\KRE-Mono.1.0.0-beta2\bin
folder.

This is probably a bug in kpm pack, but this allows it to work for now
using the system klr providing that you `kvm use 1.0.0-beta2`