### PR TITLE
Add a build.cmd for Windows users without bash

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+cd OmniSharpServer
+xbuild /p:Platform="Any CPU" /property:nowarn=1685


### PR DESCRIPTION
Just a .cmd version of build.sh