### PR TITLE
Fix OmniSharpServer.exe crash on startup

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -41,9 +41,9 @@ def current_solution_filepath_or_project_rootpath(view):
             solution_file_name = data['solution_file']
             solution_file_path = os.path.join(project_dir, solution_file_name)
             solution_file_path = os.path.abspath(solution_file_path)
-            return "\"" + solution_file_path + "\""
+            return solution_file_path
     else:
         parentpath = sublime.active_window().folders()[0] #assume parent folder is opened that contains all project folders eg/Web,ClassLib,Tests
-        return "\"" + parentpath + "\""
+        return parentpath
 
 


### PR DESCRIPTION
As a side effect from e81893656a00abcbf075fe87a17ce052c3eccbaa, the command line for OmniSharpServer.exe has double quotes on the `-s` parameter, which causes crashes when `solution_path` contains spaces.

Removing the quotes on this method looks safe for me, since the only places it's used is to build the command line and as a key on a Map.