### PR TITLE
Navigate Code Issues

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -85,12 +85,12 @@
                 "command": "omni_sharp_show_server_output",
             },
             {
-                "caption": "Next Syntax Error",
-                "command": "omni_sharp_next_syntax_error"
+                "caption": "Next Code Issue",
+                "command": "omni_sharp_next_code_issue"
             },
             {
-                "caption": "Last Syntax Error",
-                "command": "omni_sharp_last_syntax_error"
+                "caption": "Last Code Issue",
+                "command": "omni_sharp_last_code_issue"
             },
             {
                 "caption": "Build",

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -102,12 +102,12 @@
         "command": "omni_sharp_show_server_output",
     },
     {
-        "caption": "OmniSharpSublime: Next Syntax Error",
-        "command": "omni_sharp_next_syntax_error"
+        "caption": "OmniSharpSublime: Next Code Issue",
+        "command": "omni_sharp_next_code_issue"
     },
     {
-        "caption": "OmniSharpSublime: Last Syntax Error",
-        "command": "omni_sharp_last_syntax_error"
+        "caption": "OmniSharpSublime: Last Code Issue",
+        "command": "omni_sharp_last_code_issue"
     }
     }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -109,5 +109,4 @@
         "caption": "OmniSharpSublime: Last Code Issue",
         "command": "omni_sharp_last_code_issue"
     }
-    }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -13,4 +13,6 @@
     {"command": "omni_sharp_build_project", "keys":["super+alt+b"]},
     {"command": "omni_sharp_navigate_to", "keys":["ctrl+,"]},
     {"command": "omni_sharp_go_to_implementation", "keys":["super+i"]},
+    {"command": "omni_sharp_next_code_issue", "keys": ["super+m"]},
+    {"command": "omni_sharp_last_code_issue", "keys": ["super+n"]}
 ]

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -21,8 +21,8 @@ from .build_project import OmniSharpBuildProject
 from .reload_solution import OmniSharpReloadSolution
 from .navigate_to import OmniSharpNavigateTo
 from .show_server_output import OmniSharpShowServerOutput
-from .navigate_syntax_errors import OmniSharpNextSyntaxError
-from .navigate_syntax_errors import OmniSharpLastSyntaxError
+from .navigate_code_issues import OmniSharpNextCodeIssue
+from .navigate_code_issues import OmniSharpLastCodeIssue
 
 __all__ = [
     'OmniSharpGoToDefinition',
@@ -48,6 +48,6 @@ __all__ = [
     'OmniSharpReloadSolution',
     'OmniSharpNavigateTo',
     'OmniSharpShowServerOutput',
-    'OmniSharpNextSyntaxError',
-    'OmniSharpLastSyntaxError'
+    'OmniSharpNextCodeIssue',
+    'OmniSharpLastCodeIssue'
 ]

--- a/commands/navigate_code_issues.py
+++ b/commands/navigate_code_issues.py
@@ -24,9 +24,9 @@ class OmniSharpNextCodeIssue(sublime_plugin.TextCommand):
             next_region = all_regions[0]
 
         if next_region != None:
-            sel.clear()
             self.view.show_at_center(next_region)
-            sel.add(next_region)
+            sel.clear()
+            sel.add(sublime.Region(next_region.begin(), next_region.begin()))
 
     def is_enabled(self):
         oops_map = self.get_oops_map()
@@ -55,9 +55,9 @@ class OmniSharpLastCodeIssue(sublime_plugin.TextCommand):
             next_region = all_regions[-1]
 
         if next_region != None:
-            sel.clear()
             self.view.show_at_center(next_region)
-            sel.add(next_region)
+            sel.clear()
+            sel.add(sublime.Region(next_region.begin(), next_region.begin()))
 
     def is_enabled(self):
         oops_map = self.get_oops_map()

--- a/commands/navigate_code_issues.py
+++ b/commands/navigate_code_issues.py
@@ -5,7 +5,7 @@ from ..lib import omnisharp
 from ..lib import helpers
 
 
-class OmniSharpNextSyntaxError(sublime_plugin.TextCommand):
+class OmniSharpNextCodeIssue(sublime_plugin.TextCommand):
     def run(self, text):
         oops_map = self.get_oops_map()
         if None == oops_map:
@@ -36,7 +36,7 @@ class OmniSharpNextSyntaxError(sublime_plugin.TextCommand):
         return self.view.settings().get("oops")
 
 
-class OmniSharpLastSyntaxError(sublime_plugin.TextCommand):
+class OmniSharpLastCodeIssue(sublime_plugin.TextCommand):
     def run(self, text):
         oops_map = self.get_oops_map()
         if None == oops_map:

--- a/listeners/syntax.py
+++ b/listeners/syntax.py
@@ -61,6 +61,9 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
             for i in self.data["QuickFixes"]:
                 point = self.view.text_point(i["Line"]-1, i["Column"]-1)
                 reg = self.view.word(point)
+                region_that_would_be_looked_up = self.view.word(reg.begin())
+                if region_that_would_be_looked_up.begin() != reg.begin() or region_that_would_be_looked_up.end() != reg.end():
+                    reg = sublime.Region(point, point+1)
                 self.underlines.append(reg)
                 key = "%s,%s" % (reg.a, reg.b)
                 oops_map[key] = i["Text"].strip()

--- a/listeners/syntax.py
+++ b/listeners/syntax.py
@@ -13,15 +13,21 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
     outputpanel = None
     next_run_time = 0
 
-    def on_post_save(self, view):
-        self._run_codecheck(view)
+    def on_activated(self, view):
+        self._run_codecheck_after_delay(view)
 
     def on_modified(self, view):
-        timeout_ms = 500
-        self.next_run_time = time() + 0.0009 * timeout_ms
-        sublime.set_timeout(lambda:self._run_codecheck_after_delay(view), timeout_ms)
+        self._run_codecheck_after_delay(view)
+
+    def on_post_save(self, view):
+        self._run_codecheck_after_delay(view)
 
     def _run_codecheck_after_delay(self, view):
+        timeout_ms = 500
+        self.next_run_time = time() + 0.0009 * timeout_ms
+        sublime.set_timeout(lambda:self._run_codecheck_after_delay_callback(view), timeout_ms)
+
+    def _run_codecheck_after_delay_callback(self, view):
         if self.next_run_time <= time():
             self._run_codecheck(view)
 
@@ -53,7 +59,7 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
 
         if "QuickFixes" in self.data and self.data["QuickFixes"] != None and len(self.data["QuickFixes"]) > 0:
             for i in self.data["QuickFixes"]:
-                point = self.view.text_point(i["Line"]-1, i["Column"])
+                point = self.view.text_point(i["Line"]-1, i["Column"]-1)
                 reg = self.view.word(point)
                 self.underlines.append(reg)
                 key = "%s,%s" % (reg.a, reg.b)

--- a/listeners/tooltip.py
+++ b/listeners/tooltip.py
@@ -4,14 +4,25 @@ from time import time
 
 class OmniSharpTooltipListener(sublime_plugin.EventListener):
 
-    def on_activated_async(self, view):
-        self._check_tooltip(view)
+    next_run_time = 0
 
-    def on_modified_async(self, view):
-        self._check_tooltip(view)
+    def on_activated(self, view):
+        self._check_tooltip_after_delay(view)
 
-    def on_selection_modified_async(self, view):
-        self._check_tooltip(view)
+    def on_modified(self, view):
+        self._check_tooltip_after_delay(view)
+
+    def on_selection_modified(self, view):
+        self._check_tooltip_after_delay(view)
+
+    def _check_tooltip_after_delay(self, view):
+        timeout_ms = 400
+        self.next_run_time = time() + 0.0009 * timeout_ms
+        sublime.set_timeout(lambda:self._check_tooktip_after_delay_callback(view), timeout_ms)
+
+    def _check_tooktip_after_delay_callback(self, view):
+        if self.next_run_time <= time():
+            self._check_tooltip(view)
 
     def _check_tooltip(self, view):
 

--- a/listeners/tooltip.py
+++ b/listeners/tooltip.py
@@ -42,7 +42,9 @@ class OmniSharpTooltipListener(sublime_plugin.EventListener):
 
             key = "%s,%s" % (word_region.a, word_region.b)
             if key not in oops_map:
-                continue
+                key = "%s,%s" % (region.begin(), region.begin() + 1)
+                if key not in oops_map:
+                    continue
             issue = oops_map[key]
 
             css = "html {background-color: #232628; color: #CCCCCC; } body {font-size: 12px; } a {color: #6699cc; } b {color: #cc99cc; } h1 {color: #99cc99; font-size: 14px; }"


### PR DESCRIPTION
These additions allow you to easily navigate between code issues. This supports wrapping over the ends of the document.

To test, I added the following to my `.sublime-keymap` to let me jump forward or backward:

```
    {"command": "omni_sharp_next_code_issue", "keys": ["super+m"]},
    {"command": "omni_sharp_last_code_issue", "keys": ["super+n"]}
```