### PR TITLE
Fix for issue #93 "After running code action, no cursor is present"

### DIFF
--- a/commands/code_actions.py
+++ b/commands/code_actions.py
@@ -104,4 +104,3 @@ class OmniSharpRunCodeAction(sublime_plugin.TextCommand):
   def run(self, edit, args):
     region = sublime.Region(0, self.view.size())
     self.view.replace(edit, region, args['text'])
-    self.view.sel().clear()


### PR DESCRIPTION
Removed the call to clear selection after the code action. It causes the
issue and removing it doesn't seem to have any side effects.