### PR TITLE
Append OSX PATH instead of prepending

### DIFF
--- a/PrebuiltOmniSharpServer/omnisharp
+++ b/PrebuiltOmniSharpServer/omnisharp
@@ -9,6 +9,6 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # export SET KRE_APPBASE="$DIR/approot/packages/OmniSharp/1.0.0/root"
-export PATH=$PATH:/usr/local/bin # this is required for the users of the Homebrew Mono package
+export PATH=/usr/local/bin:$PATH # this is required for the users of the Homebrew Mono package
 
 exec mono "$DIR/OmniSharp.exe" "$@"


### PR DESCRIPTION
Put `/usr/local/bin` at front of existing PATH so executables there get picked up first.