### PR TITLE
Ensure the output panel is scrolled to top when it opens

### DIFF
--- a/listeners/syntax.py
+++ b/listeners/syntax.py
@@ -99,4 +99,6 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
 
         self.data = None
 
+        # Make error panel be scrolled to top so that we can see the first error:
+        self.outputpanel.view.set_viewport_position((0,0))
 


### PR DESCRIPTION
This change fixes an issue where the output panel will open with its contents scrolled to the bottom if they can't fit vertically, which is a nuisance since the user will often have to manually scroll it up in order to see the first and most relevant messages.