### PR TITLE
Added setting for suppressing "hidden" messages in the output panel

### DIFF
--- a/OmniSharpSublime.sublime-settings
+++ b/OmniSharpSublime.sublime-settings
@@ -19,5 +19,6 @@
     "omnisharp_onsave_codecheck": true,
     "omnisharp_show_override_completion": true,
     "omnisharp_showwarningwindows":true,
-    "omnisharp_showerrorwindows":true
+    "omnisharp_showerrorwindows":true,
+    "omnisharp_suppresshidden":false
 }

--- a/listeners/syntax.py
+++ b/listeners/syntax.py
@@ -67,6 +67,7 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
         if "QuickFixes" in self.data and self.data["QuickFixes"] != None and len(self.data["QuickFixes"]) > 0:
             self.data["QuickFixes"].sort(key = lambda a:(a['Line'],a['Column']))
             self.outputpanel.write_line("File: "+self.data["QuickFixes"][0]["FileName"]+"\n")
+            suppressHidden = bool(helpers.get_settings(self.view,'omnisharp_suppresshidden'))
             for i in self.data["QuickFixes"]:
                 point = self.view.text_point(i["Line"]-1, i["Column"]-1)
                 reg = self.view.word(point)
@@ -74,6 +75,9 @@ class OmniSharpSyntaxEventListener(sublime_plugin.EventListener):
                 if region_that_would_be_looked_up.begin() != reg.begin() or region_that_would_be_looked_up.end() != reg.end():
                     reg = sublime.Region(point, point+1)
                 # self.underlines.append(reg)
+
+                if i["LogLevel"] == "Hidden" and suppressHidden:
+                    continue
                 if i["LogLevel"] == "Warning" :
                     self.warninglines.append(reg)
                 if i["LogLevel"] == "Error" :


### PR DESCRIPTION
As I worked with omnisharp-sublime I found that the "hidden" level messages that were appearing in the output panel were not something I cared to see and were cluttering things up. So I added a preference that can suppress them by adding:

    "omnisharp_suppresshidden": true

...to omnisharp-sublime's user settings. The setting is false by default so the user has to opt in.